### PR TITLE
web address setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-
+site/
 docs/.DS_Store
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ## Documentation
 
-The documentation for the ELIXIR Beacon v2 Network is [here](https://elixir-europe.github.io/beacon-network/)
+The documentation for the ELIXIR Beacon v2 Network is [here](https://ga4gh-beacon.github.io/beacon-network/)
 
 ## Deploying
 
-Frontend repository is located [here](https://github.com/elixir-europe/beacon-network-ui).
-Backend repository is [here](https://github.com/elixir-europe/beacon-network-backend).
+Frontend repository is located [here](https://github.com/ga4gh-beacon/beacon-network-ui).
+Backend repository is [here](https://github.com/ga4gh-beacon/beacon-network-backend).
 
-For deploying both repositories at once you must use the [Docker implementation](https://github.com/elixir-europe/beacon-network-docker).
+For deploying both repositories at once you must use the [Docker implementation](https://github.com/ga4gh-beacon/beacon-network-docker).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Documentation
 
-The documentation for the ELIXIR Beacon v2 Network is [here](https://beacon-network-v2-documentation.readthedocs.io/en/latest/)
+The documentation for the ELIXIR Beacon v2 Network is [here](https://elixir-europe.github.io/beacon-network/)
 
 ## Deploying
 

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+network.genomebeacons.org

--- a/docs/mainDocumentation/governanceModel.md
+++ b/docs/mainDocumentation/governanceModel.md
@@ -114,7 +114,7 @@ The official communication channels for user support and project discussions in 
 
 - The Gitter messaging system channel for the ecosystem.
 
-- Via issues in any of the [Beacon Network repositories](https://github.com/elixir-europe/beacon-network).
+- Via issues in any of the [Beacon Network repositories](https://github.com/ga4gh-beacon/beacon-network).
 
 
 # 6. Support

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -21,9 +21,9 @@ site_description: 'Website for the ELIXIR Beacon v2 Network Project'
 site_author: 'Sergi Aguiló Castillo, Michael Baudis & Beacon Network Developers'
 copyright: '&copy; Copyright 2024, ELIXIR Beacon Developers'
 repo_name: 'beacon-network'
-repo_url: https://github.com/elixir-europe/beacon-network
+repo_url: https://github.com/ga4gh-beacon/beacon-network
 edit_uri: edit/main/docs/
-repo_icon: " [:fontawesome-brands-github:](https://github.com/elixir-europe/beacon-network/tree/main/docs)"
+repo_icon: " [:fontawesome-brands-github:](https://github.com/ga4gh-beacon/beacon-network/tree/main/docs)"
 
 # ------------------- Mkdocs Configurattion and Extensions-------------------- #
 


### PR DESCRIPTION
The README had a link to a unnecessary readthedocs build. Such a setup has problemes since it introduces a dependency to another cloud service with all additional management etc. overhead.

Additionally this PR places a CNAME entry for a yet to be configured `network.genomebeacons.org` subdomain which in the long run should be used as stable reference independent of the hosting solution (again: not yet configured).